### PR TITLE
Update podspec

### DIFF
--- a/PagedHorizontalView.podspec
+++ b/PagedHorizontalView.podspec
@@ -27,6 +27,6 @@ It doesn't affect the appearance of the controls and doesn't implement the colle
   s.platform     = :ios, '8.0'
   s.requires_arc = true
 
-  s.source_files = 'PagedHorizontalView/**/*'
+  s.source_files = 'PagedHorizontalView/**/*.{swift,h}'
 
 end


### PR DESCRIPTION
When everything is passed a resource the plist get's added twice
because Xcode adds it anyway. This ends in a compiler error